### PR TITLE
將視覺化功能重構為獨立模組（解決 Issue #11）

### DIFF
--- a/utils/visualization/__init__.py
+++ b/utils/visualization/__init__.py
@@ -1,0 +1,17 @@
+"""
+Visualization module for audio angle classification.
+
+This module provides visualization utilities for training history, 
+gradient distributions, and other plotting needs.
+"""
+
+from utils.visualization.training_visualizer import plot_training_history
+from utils.visualization.ghm_visualizer import plot_ghm_statistics, plot_gradient_distribution
+from utils.visualization.plot_utils import set_plot_style
+
+__all__ = [
+    'plot_training_history',
+    'plot_ghm_statistics',
+    'plot_gradient_distribution',
+    'set_plot_style'
+] 

--- a/utils/visualization/ghm_visualizer.py
+++ b/utils/visualization/ghm_visualizer.py
@@ -1,0 +1,83 @@
+"""
+Gradient Harmonizing Mechanism (GHM) visualization utilities.
+
+This module provides functions for visualizing GHM-related statistics and
+gradient distributions during training.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import torch
+from utils.visualization.plot_utils import create_figure, save_figure, ensure_directory_exists
+
+def plot_ghm_statistics(criterion, outputs1, outputs2, targets, save_dir, name):
+    """Plot and save GHM statistics.
+    
+    Args:
+        criterion: GHMRankingLoss instance
+        outputs1 (torch.Tensor): Model outputs for first samples
+        outputs2 (torch.Tensor): Model outputs for second samples
+        targets (torch.Tensor): Target values
+        save_dir (str): Directory to save plot files
+        name (str): Base name for plot files
+        
+    Returns:
+        dict: Statistics from the GHM calculation
+    """
+    from utils import ghm_utils  # Import here to avoid circular imports
+    
+    # Calculate GHM statistics
+    stats = ghm_utils.calculate_ghm_statistics(
+        criterion, outputs1, outputs2, targets,
+        save_dir=save_dir,
+        name=name
+    )
+    
+    # Create additional visualization if needed
+    plot_gradient_distribution(criterion, save_dir=save_dir, name=name)
+    
+    return stats
+
+def plot_gradient_distribution(criterion, save_dir, name, figsize=(10, 8)):
+    """Plot the gradient distribution from GHM loss.
+    
+    Args:
+        criterion: GHMRankingLoss instance
+        save_dir (str): Directory to save the plot
+        name (str): Base name for the plot file
+        figsize (tuple): Figure size in inches
+        
+    Returns:
+        str: Path to the saved plot file
+    """
+    # Skip if criterion is not GHMRankingLoss or edges not initialized
+    if not hasattr(criterion, 'edges') or not hasattr(criterion, 'distribution'):
+        return None
+    
+    fig = create_figure(figsize)
+    
+    # Plot distribution histogram
+    edges = criterion.edges.cpu().numpy()
+    bins = len(edges) - 1
+    
+    if hasattr(criterion, 'distribution') and criterion.distribution is not None:
+        dist = criterion.distribution.cpu().numpy()
+        bin_widths = np.diff(edges)
+        plt.bar(edges[:-1], dist / bin_widths, width=bin_widths, alpha=0.7)
+    
+    # Plot edges
+    for edge in edges:
+        plt.axvline(x=edge, color='r', linestyle='--', alpha=0.3)
+    
+    plt.xlabel('Gradient Magnitude')
+    plt.ylabel('Density')
+    plt.grid(True, alpha=0.3)
+    plt.title('Gradient Distribution with GHM Edges')
+    
+    # Save figure
+    ensure_directory_exists(save_dir)
+    save_path = os.path.join(save_dir, f"{name}_gradient_dist.png")
+    save_figure(fig, save_path)
+    
+    return save_path 

--- a/utils/visualization/plot_utils.py
+++ b/utils/visualization/plot_utils.py
@@ -1,0 +1,56 @@
+"""
+Common plotting utilities for visualization across the project.
+
+This module provides shared functions for plot styling, configuration,
+and other general plotting tasks used by multiple visualization components.
+"""
+
+import matplotlib.pyplot as plt
+import os
+
+def set_plot_style(style='default'):
+    """Set the global matplotlib style for consistent visualization.
+    
+    Args:
+        style (str): The style to use. Options include 'default', 'scientific', etc.
+                     Default is 'default'.
+    """
+    if style == 'scientific':
+        plt.style.use('seaborn-v0_8-whitegrid')
+    elif style == 'presentation':
+        plt.style.use('seaborn-v0_8-talk')
+    else:  # default
+        # Use more generic style that should be widely available
+        plt.style.use('ggplot')
+
+def ensure_directory_exists(directory):
+    """Ensure that the target directory exists, creating it if necessary.
+    
+    Args:
+        directory (str): Path to the directory to check/create.
+    """
+    os.makedirs(directory, exist_ok=True)
+    
+def save_figure(fig, save_path, dpi=300, bbox_inches='tight'):
+    """Save a matplotlib figure with standardized settings.
+    
+    Args:
+        fig (matplotlib.figure.Figure): The figure to save
+        save_path (str): Path where the figure should be saved
+        dpi (int): Resolution in dots per inch
+        bbox_inches (str): Bounding box setting
+    """
+    ensure_directory_exists(os.path.dirname(save_path))
+    fig.savefig(save_path, dpi=dpi, bbox_inches=bbox_inches)
+    plt.close(fig)  # Close figure to free memory
+    
+def create_figure(figsize=(12, 10)):
+    """Create a figure with standard sizing.
+    
+    Args:
+        figsize (tuple): Width, height in inches
+        
+    Returns:
+        matplotlib.figure.Figure: A new figure
+    """
+    return plt.figure(figsize=figsize) 

--- a/utils/visualization/test_visualization.py
+++ b/utils/visualization/test_visualization.py
@@ -1,0 +1,98 @@
+"""
+Test script for visualization module.
+
+This script tests the functionality of the visualization module 
+by creating sample data and visualizing it.
+"""
+
+import os
+import sys
+import torch
+import numpy as np
+from datetime import datetime
+
+# Add root to path to ensure imports work
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from losses.ghm_loss import GHMRankingLoss
+from utils.visualization import plot_training_history, plot_ghm_statistics, plot_gradient_distribution, set_plot_style
+
+def create_sample_history():
+    """Create a sample training history for testing visualization."""
+    epochs = 30
+    
+    # Create a sample history dictionary
+    history = {
+        'epoch': list(range(1, epochs + 1)),
+        'train_loss_main': [1.0 - i * 0.03 + 0.001 * np.random.rand() for i in range(epochs)],
+        'val_loss_main': [1.05 - i * 0.025 + 0.005 * np.random.rand() for i in range(epochs)],
+        'train_accuracy': [60 + i * 1.2 + 0.5 * np.random.rand() for i in range(epochs)],
+        'val_accuracy': [58 + i * 1.1 + 0.7 * np.random.rand() for i in range(epochs)],
+        'train_loss_standard_log': [1.1 - i * 0.028 + 0.002 * np.random.rand() for i in range(epochs)],
+        'val_loss_standard_log': [1.15 - i * 0.022 + 0.006 * np.random.rand() for i in range(epochs)],
+        'args': {
+            'loss_type': 'ghm',
+            'frequency': '1000hz',
+            'material': 'plastic'
+        }
+    }
+    
+    return history
+
+def create_sample_ghm_outputs():
+    """Create sample GHM outputs for testing visualization."""
+    # Create a simple GHMRankingLoss instance
+    criterion = GHMRankingLoss(margin=1.0, bins=10, alpha=0.75)
+    
+    # Create sample outputs and targets
+    batch_size = 16
+    outputs1 = torch.randn(batch_size)
+    outputs2 = torch.randn(batch_size)
+    targets = torch.sign(outputs1 - outputs2 + 0.1 * torch.randn(batch_size))
+    
+    # Initialize edges and distributions (normally done by criterion during forward pass)
+    criterion.edges = torch.linspace(0, 10, 11)
+    criterion.distribution = torch.zeros(10)
+    criterion.distribution[0:5] = torch.tensor([8, 5, 3, 2, 1])
+    
+    return criterion, outputs1, outputs2, targets
+
+def main():
+    """Test visualization module functionality."""
+    print("Testing visualization module...")
+    
+    # Set a consistent style
+    set_plot_style('default')
+    
+    # Create test output directory
+    test_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_output')
+    os.makedirs(test_dir, exist_ok=True)
+    
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    
+    # Test training history visualization
+    print("\nTesting training history visualization...")
+    history = create_sample_history()
+    history_plot_path = os.path.join(test_dir, f'test_history_plot_{timestamp}.png')
+    plot_training_history(history, history_plot_path)
+    print(f"  Plot saved to: {history_plot_path}")
+    
+    # Test GHM visualization
+    print("\nTesting GHM visualization...")
+    criterion, outputs1, outputs2, targets = create_sample_ghm_outputs()
+    ghm_stats_path = os.path.join(test_dir, f'test_ghm_stats_{timestamp}')
+    os.makedirs(ghm_stats_path, exist_ok=True)
+    
+    # Test direct gradient distribution plotting
+    grad_dist_path = os.path.join(test_dir, f'grad_dist_{timestamp}')
+    plot_gradient_distribution(criterion, test_dir, grad_dist_path)
+    print(f"  Gradient distribution plot saved to: {os.path.join(test_dir, f'{grad_dist_path}_gradient_dist.png')}")
+    
+    # Test GHM statistics plotting
+    plot_ghm_statistics(criterion, outputs1, outputs2, targets, test_dir, f'ghm_stats_{timestamp}')
+    print(f"  GHM statistics visualized in: {test_dir}")
+    
+    print("\nAll visualization tests completed successfully!")
+
+if __name__ == "__main__":
+    main() 

--- a/utils/visualization/training_visualizer.py
+++ b/utils/visualization/training_visualizer.py
@@ -1,0 +1,81 @@
+"""
+Training visualization utilities for the audio angle classification project.
+
+This module provides functions for visualizing training metrics such as
+loss and accuracy over epochs.
+"""
+
+import matplotlib.pyplot as plt
+import os
+from utils.visualization.plot_utils import create_figure, save_figure, ensure_directory_exists
+
+def plot_training_history(
+    history, 
+    save_path, 
+    title_prefix="Training and Validation", 
+    figsize=(12, 10),
+    include_standard_loss=True
+):
+    """Plot training history metrics including loss and accuracy.
+    
+    Args:
+        history (dict): Dictionary containing training history with keys:
+            - 'epoch' (list): Epoch numbers
+            - 'train_loss_main' (list): Training loss values 
+            - 'val_loss_main' (list): Validation loss values
+            - 'train_accuracy' (list): Training accuracy values
+            - 'val_accuracy' (list): Validation accuracy values
+            - 'train_loss_standard_log' (list, optional): Standard loss values for training
+            - 'val_loss_standard_log' (list, optional): Standard loss values for validation
+            - 'args' (dict): Arguments used for training including loss_type, frequency, material
+            
+        save_path (str): Path where the plot will be saved
+        title_prefix (str): Prefix for plot titles
+        figsize (tuple): Figure size (width, height) in inches
+        include_standard_loss (bool): Whether to include standard loss plots for GHM loss
+        
+    Returns:
+        str: Path where the plot was saved
+    """
+    # Extract training parameters
+    args = history.get('args', {})
+    loss_type = args.get('loss_type', 'unknown')
+    frequency = args.get('frequency', 'unknown')
+    material = args.get('material', 'unknown')
+    
+    # Create figure with two subplots
+    fig = create_figure(figsize)
+    
+    # Loss plot
+    plt.subplot(2, 1, 1)
+    plt.plot(history['epoch'], history['train_loss_main'], 'b-', label=f'Train Loss ({loss_type})')
+    plt.plot(history['epoch'], history['val_loss_main'], 'r-', label=f'Val Loss ({loss_type})')
+    
+    # Optionally plot standard loss if GHM was used and include_standard_loss is True
+    if include_standard_loss and loss_type == 'ghm' and 'train_loss_standard_log' in history and 'val_loss_standard_log' in history:
+        plt.plot(history['epoch'], history['train_loss_standard_log'], 'c--', label='Train Loss (Standard Log)')
+        plt.plot(history['epoch'], history['val_loss_standard_log'], 'm--', label='Val Loss (Standard Log)')
+    
+    plt.grid(True)
+    plt.xlabel('Epoch')
+    plt.ylabel('Loss')
+    plt.legend()
+    plt.title(f'{title_prefix} Loss ({frequency} / {material})')
+    
+    # Accuracy plot
+    plt.subplot(2, 1, 2)
+    plt.plot(history['epoch'], history['train_accuracy'], 'b-', label='Train Accuracy')
+    plt.plot(history['epoch'], history['val_accuracy'], 'r-', label='Val Accuracy')
+    plt.grid(True)
+    plt.xlabel('Epoch')
+    plt.ylabel('Accuracy (%)')
+    plt.legend()
+    plt.title(f'{title_prefix} Accuracy ({frequency} / {material})')
+    
+    plt.tight_layout()
+    
+    # Save figure
+    ensure_directory_exists(os.path.dirname(save_path))
+    save_figure(fig, save_path)
+    
+    return save_path 


### PR DESCRIPTION
## 摘要
這個 PR 解決了 Issue #11，將 train.py 中的視覺化功能重構為獨立模組。

## 主要變更
1. 創建了新的視覺化模組結構：
   - `utils/visualization/__init__.py` - 導出主要函數
   - `utils/visualization/training_visualizer.py` - 處理訓練歷史視覺化
   - `utils/visualization/ghm_visualizer.py` - 處理 GHM 統計和梯度分布視覺化
   - `utils/visualization/plot_utils.py` - 共享的繪圖工具函數
   - `utils/visualization/test_visualization.py` - 測試腳本

2. 更新了 train.py 以使用新的視覺化模組：
   - 移除了直接的 matplotlib 繪圖代碼
   - 使用新的模組 API 進行視覺化
  
## 測試
添加了 `test_visualization.py` 測試腳本，確保視覺化模組正常工作。測試覆蓋了：
- 訓練歷史的繪圖功能
- GHM 統計和梯度分布的視覺化功能

## 相關 Issue
- 解決 #11