### PR TITLE
Add quality metrics integration to diagnose_and_remediate_data.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 *.pkl
 
 saved_models/
+
+# Ignore diagnostics results directories
+scripts/diagnostics_results_*/

--- a/scripts/diagnose_and_remediate_data.py
+++ b/scripts/diagnose_and_remediate_data.py
@@ -17,9 +17,10 @@ import sys
 import argparse
 import torch
 import numpy as np
+import json
 from datetime import datetime
 import matplotlib.pyplot as plt
-from torch.utils.data import DataLoader, random_split
+from torch.utils.data import DataLoader, random_split, Subset
 
 # 添加項目根目錄到Python路徑以確保import正常工作
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -33,7 +34,14 @@ from utils.common_utils import set_seed
 from utils.data_diagnostics import (
     ProblemSampleDetector,
     DiagnosticsVisualizer,
-    RemediationStrategies
+    RemediationStrategies,
+    # 直接導入質量指標函數
+    calculate_sample_difficulty,
+    calculate_sample_influence,
+    calculate_feature_space_density,
+    calculate_prediction_stability,
+    calculate_loss_landscape,
+    calculate_comprehensive_quality_score
 )
 
 def parse_arguments():
@@ -75,6 +83,13 @@ def parse_arguments():
     # 可視化參數
     parser.add_argument('--visualize', action='store_true',
                         help='生成可視化結果')
+    
+    # 質量指標參數
+    parser.add_argument('--quality-metrics', action='store_true',
+                        help='計算樣本質量指標')
+    
+    parser.add_argument('--num-samples', type=int, default=10,
+                        help='要計算質量指標的樣本數量 (默認: 10)')
     
     # 其他參數
     parser.add_argument('--model-path', type=str, default=None,

--- a/scripts/diagnose_and_remediate_data.py
+++ b/scripts/diagnose_and_remediate_data.py
@@ -669,8 +669,11 @@ def main():
     # 加載或訓練模型
     model = load_or_train_model(args, dataset, device)
     
-    # 計算質量指標
-    quality_metrics = calculate_quality_metrics_for_samples(model, dataset, output_dirs['logs'], args.num_samples, device)
+    # 如果指定了計算質量指標，則計算樣本質量
+    if args.quality_metrics:
+        quality_results = calculate_quality_metrics_for_samples(
+            model, dataset, output_dirs['logs'], args.num_samples, device
+        )
     
     # 診斷問題樣本
     detector = diagnose_problems(model, dataset, args, output_dirs)


### PR DESCRIPTION
This PR adds integration with the quality_metrics.py module in the data diagnostics utilities.

## Changes Made

1. Add imports for quality metrics functions from utils.data_diagnostics
2. Add command-line arguments --quality-metrics and --num-samples to control the quality metrics analysis
3. Add a comprehensive function for calculating and storing quality metrics for data samples
4. Update the main function to conditionally use the quality metrics analysis when requested

## Details

The implementation now allows users to analyze samples using all six quality metrics functions:
- calculate_sample_difficulty
- calculate_sample_influence
- calculate_feature_space_density
- calculate_prediction_stability
- calculate_loss_landscape
- calculate_comprehensive_quality_score

Example usage:
```
python scripts/diagnose_and_remediate_data.py --frequency 1000hz --material plastic --quality-metrics --num-samples 5
```

The quality metrics results are saved in JSON format in the logs directory for further analysis.