### PR TITLE
添加檢查點影響力可視化功能

### DIFF
--- a/analyze_per_checkpoint_influences.py
+++ b/analyze_per_checkpoint_influences.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+"""
+分析每個檢查點的TracIn影響分數，追蹤訓練過程中影響分數的變化。
+
+此腳本可以識別：
+1. 每個檢查點中對測試樣本有最大影響的訓練樣本
+2. 訓練過程中影響分數變化最顯著的訓練樣本
+3. 不同檢查點之間影響分數的趨勢變化
+"""
+
+import os
+import json
+import argparse
+import re
+import numpy as np
+import matplotlib.pyplot as plt
+from collections import defaultdict
+
+
+def extract_degrees(sample_id):
+    """從樣本ID中提取角度信息。"""
+    parts = sample_id.split("_")
+    first_deg, second_deg = 0, 0
+    
+    # 尋找包含"deg"的部分，並提取角度值
+    for part in parts:
+        if part.startswith("deg"):
+            try:
+                deg_value = int(part[3:])  # 提取"deg"後的數字
+                if first_deg == 0:
+                    first_deg = deg_value
+                else:
+                    second_deg = deg_value
+                    break
+            except ValueError:
+                continue
+    
+    if first_deg == 0 and second_deg == 0:
+        print(f"警告: 無法從樣本ID '{sample_id}'提取角度值")
+    
+    return first_deg, second_deg
+
+
+def extract_checkpoint_epoch(checkpoint_name):
+    """從檢查點名稱中提取epoch編號。"""
+    match = re.search(r'epoch_(\d+)\.pt', checkpoint_name)
+    if match:
+        return int(match.group(1))
+    else:
+        # 嘗試其他可能的格式
+        match = re.search(r'(\d+)\.pt', checkpoint_name)
+        if match:
+            return int(match.group(1))
+        return -1  # 無法提取epoch編號
+
+
+def parse_args():
+    """解析命令行參數。"""
+    parser = argparse.ArgumentParser(description="分析每個檢查點的TracIn影響分數")
+    parser.add_argument("--metadata-dir", type=str, default="/Users/sbplab/Hank/sinetone_sliced/step_018_sliced/metadata",
+                        help="元數據目錄")
+    parser.add_argument("--material", type=str, default="plastic",
+                        help="材料類型")
+    parser.add_argument("--frequency", type=str, default="500hz",
+                        help="頻率數據")
+    parser.add_argument("--test-sample", type=str, default=None,
+                        help="要分析的特定測試樣本ID (如果不指定，將選擇前幾個)")
+    parser.add_argument("--num-test-samples", type=int, default=3,
+                        help="要分析的測試樣本數量 (如果不指定特定樣本)")
+    parser.add_argument("--top-n", type=int, default=5,
+                        help="每個檢查點顯示的前N個影響樣本")
+    parser.add_argument("--save-plots", action="store_true",
+                        help="將圖表保存為PNG文件而不是顯示")
+    parser.add_argument("--output-dir", type=str, default="tracin_plots",
+                        help="保存圖表的目錄")
+    return parser.parse_args()
+
+
+def load_per_checkpoint_metadata(metadata_dir, material, frequency):
+    """加載每個檢查點的影響分數元數據。"""
+    metadata_file = os.path.join(
+        metadata_dir, 
+        f"{material}_{frequency}_per_checkpoint_influence_metadata.json"
+    )
+    
+    if not os.path.exists(metadata_file):
+        raise FileNotFoundError(f"找不到每個檢查點的影響分數文件: {metadata_file}")
+    
+    with open(metadata_file, 'r') as f:
+        return json.load(f)
+
+
+def identify_test_samples(metadata):
+    """識別元數據中的測試樣本。"""
+    test_samples = set()
+    pattern = re.compile(r"tracin_influence_(.*?)_model_")
+    
+    for train_id, scores in metadata.items():
+        for score_name in scores.keys():
+            match = pattern.search(score_name)
+            if match:
+                test_samples.add(match.group(1))
+    
+    return sorted(list(test_samples))
+
+
+def identify_checkpoints(metadata):
+    """識別元數據中的檢查點。"""
+    checkpoints = set()
+    pattern = re.compile(r"_(model_.*?\.pt)$")
+    
+    for train_id, scores in metadata.items():
+        for score_name in scores.keys():
+            match = pattern.search(score_name)
+            if match:
+                checkpoints.add(match.group(1))
+    
+    # 按照epoch編號排序檢查點
+    return sorted(list(checkpoints), key=extract_checkpoint_epoch)
+
+
+def find_influential_samples_per_checkpoint(metadata, test_sample, checkpoints, top_n=5):
+    """為測試樣本找出每個檢查點中最具影響力的訓練樣本。"""
+    results = {}
+    
+    for checkpoint in checkpoints:
+        # 收集此檢查點對測試樣本的所有影響分數
+        influences = []
+        score_prefix = f"tracin_influence_{test_sample}_{checkpoint}"
+        
+        for train_id, scores in metadata.items():
+            for score_name, score in scores.items():
+                if score_name == score_prefix:
+                    influences.append((train_id, score))
+        
+        # 按絕對影響力排序
+        influences_by_abs = sorted(influences, key=lambda x: abs(x[1]), reverse=True)
+        
+        # 按正面影響力排序
+        influences_positive = sorted(influences, key=lambda x: x[1], reverse=True)
+        
+        # 按負面影響力排序
+        influences_negative = sorted(influences, key=lambda x: x[1])
+        
+        results[checkpoint] = {
+            "top_by_abs": influences_by_abs[:top_n],
+            "top_positive": influences_positive[:top_n],
+            "top_negative": influences_negative[:top_n]
+        }
+    
+    return results
+
+
+def find_samples_with_changing_influence(results, checkpoints):
+    """找出在訓練過程中影響力變化最顯著的樣本。"""
+    # 追蹤每個訓練樣本在所有檢查點中的影響力變化
+    sample_influences = defaultdict(list)
+    
+    for checkpoint in checkpoints:
+        # 記錄所有出現在top_by_abs中的樣本
+        for train_id, influence in results[checkpoint]["top_by_abs"]:
+            sample_influences[train_id].append((checkpoint, influence))
+    
+    # 計算每個樣本的影響力變化範圍
+    sample_changes = {}
+    for train_id, influences in sample_influences.items():
+        if len(influences) > 1:  # 至少在兩個檢查點中出現
+            values = [infl for _, infl in influences]
+            sample_changes[train_id] = max(values) - min(values)
+    
+    # 按變化幅度排序
+    sorted_changes = sorted(sample_changes.items(), key=lambda x: abs(x[1]), reverse=True)
+    
+    return sorted_changes[:10], sample_influences
+
+
+def plot_influence_trends(test_sample, sample_influences, checkpoints, args):
+    """繪製訓練樣本對測試樣本的影響力變化趨勢。"""
+    plt.figure(figsize=(12, 8))
+    
+    # 選擇影響力變化最大的前N個樣本
+    top_changing_samples = sorted(
+        sample_influences.items(), 
+        key=lambda x: max([abs(infl) for _, infl in x[1]]),
+        reverse=True
+    )[:8]
+    
+    # 簡化檢查點名稱 (僅保留epoch編號)
+    checkpoint_epochs = [extract_checkpoint_epoch(cp) for cp in checkpoints]
+    
+    # 為每個樣本構建完整的影響力序列 (在所有檢查點上)
+    for train_id, influences in top_changing_samples:
+        # 創建一個影響力字典，用檢查點作為鍵
+        influence_dict = {checkpoint: 0 for checkpoint in checkpoints}
+        for checkpoint, infl in influences:
+            influence_dict[checkpoint] = infl
+        
+        # 提取角度
+        train_deg1, train_deg2 = extract_degrees(train_id)
+        
+        # 繪製影響力變化趨勢
+        plt.plot(
+            checkpoint_epochs,
+            [influence_dict[cp] for cp in checkpoints],
+            marker='o',
+            label=f"{train_id} [{train_deg1}→{train_deg2}]"
+        )
+    
+    test_deg1, test_deg2 = extract_degrees(test_sample)
+    plt.title(f"測試樣本 {test_sample} [{test_deg1}→{test_deg2}] 的影響力變化趨勢")
+    plt.xlabel("訓練階段 (Epoch)")
+    plt.ylabel("影響力分數")
+    plt.grid(True, linestyle='--', alpha=0.7)
+    plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    plt.tight_layout()
+    
+    if args.save_plots:
+        # 創建輸出目錄
+        os.makedirs(args.output_dir, exist_ok=True)
+        # 保存圖表
+        plt.savefig(os.path.join(args.output_dir, f"influence_trends_{test_sample}.png"), dpi=300)
+    else:
+        plt.show()
+
+
+def print_results_per_checkpoint(test_sample, results, checkpoints):
+    """打印每個檢查點的影響力分析結果。"""
+    test_deg1, test_deg2 = extract_degrees(test_sample)
+    print(f"\n==== 測試樣本: {test_sample} [角度: {test_deg1}→{test_deg2}] ====")
+    
+    for checkpoint in checkpoints:
+        epoch = extract_checkpoint_epoch(checkpoint)
+        print(f"\n  檢查點: {checkpoint} (Epoch {epoch})")
+        
+        print("    最大絕對影響:")
+        for train_id, influence in results[checkpoint]["top_by_abs"]:
+            train_deg1, train_deg2 = extract_degrees(train_id)
+            print(f"      {train_id} [角度: {train_deg1}→{train_deg2}]: {influence:.4f}")
+        
+        print("    最大正面影響:")
+        for train_id, influence in results[checkpoint]["top_positive"][:3]:
+            if influence <= 0:
+                continue
+            train_deg1, train_deg2 = extract_degrees(train_id)
+            print(f"      {train_id} [角度: {train_deg1}→{train_deg2}]: {influence:.4f}")
+        
+        print("    最大負面影響:")
+        for train_id, influence in results[checkpoint]["top_negative"][:3]:
+            if influence >= 0:
+                continue
+            train_deg1, train_deg2 = extract_degrees(train_id)
+            print(f"      {train_id} [角度: {train_deg1}→{train_deg2}]: {influence:.4f}")
+
+
+def print_changing_influences(changing_samples, sample_influences, checkpoints):
+    """打印影響力變化最顯著的樣本。"""
+    print("\n==== 影響力變化最顯著的訓練樣本 ====")
+    
+    for train_id, change in changing_samples:
+        train_deg1, train_deg2 = extract_degrees(train_id)
+        influences = sample_influences[train_id]
+        
+        # 整理影響力變化數據
+        influence_dict = {}
+        for checkpoint, infl in influences:
+            epoch = extract_checkpoint_epoch(checkpoint)
+            influence_dict[epoch] = infl
+        
+        # 按epoch排序
+        sorted_epochs = sorted(influence_dict.keys())
+        
+        print(f"\n訓練樣本: {train_id} [角度: {train_deg1}→{train_deg2}]")
+        print(f"  影響力變化幅度: {change:.4f}")
+        print("  各檢查點影響力:")
+        for epoch in sorted_epochs:
+            print(f"    Epoch {epoch}: {influence_dict[epoch]:.4f}")
+
+
+def main():
+    """主函數。"""
+    args = parse_args()
+    
+    # 加載每個檢查點的影響分數元數據
+    metadata = load_per_checkpoint_metadata(args.metadata_dir, args.material, args.frequency)
+    
+    # 識別測試樣本
+    all_test_samples = identify_test_samples(metadata)
+    print(f"發現 {len(all_test_samples)} 個測試樣本")
+    
+    # 識別檢查點
+    checkpoints = identify_checkpoints(metadata)
+    print(f"發現 {len(checkpoints)} 個檢查點")
+    
+    # 選擇要分析的測試樣本
+    test_samples_to_analyze = []
+    if args.test_sample:
+        if args.test_sample in all_test_samples:
+            test_samples_to_analyze.append(args.test_sample)
+        else:
+            print(f"警告: 指定的測試樣本 '{args.test_sample}' 不在元數據中")
+            test_samples_to_analyze = all_test_samples[:args.num_test_samples]
+    else:
+        test_samples_to_analyze = all_test_samples[:args.num_test_samples]
+    
+    # 分析每個測試樣本
+    for test_sample in test_samples_to_analyze:
+        # 找出每個檢查點中最具影響力的訓練樣本
+        results = find_influential_samples_per_checkpoint(
+            metadata, test_sample, checkpoints, top_n=args.top_n
+        )
+        
+        # 找出影響力變化最顯著的樣本
+        changing_samples, sample_influences = find_samples_with_changing_influence(
+            results, checkpoints
+        )
+        
+        # 打印每個檢查點的結果
+        print_results_per_checkpoint(test_sample, results, checkpoints)
+        
+        # 打印影響力變化最顯著的樣本
+        print_changing_influences(changing_samples, sample_influences, checkpoints)
+        
+        # 繪製影響力變化趨勢
+        plot_influence_trends(test_sample, sample_influences, checkpoints, args)
+
+
+if __name__ == "__main__":
+    main() 

--- a/visualize_checkpoint_influences.py
+++ b/visualize_checkpoint_influences.py
@@ -1,0 +1,392 @@
+import json
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+import re
+from collections import defaultdict
+from pathlib import Path
+
+# Set the style
+plt.style.use('ggplot')
+sns.set_palette("viridis")
+
+# Create directory for visualizations
+os.makedirs('tracin_visualizations/checkpoints', exist_ok=True)
+
+def extract_degrees(sample_id):
+    """Extract degree information from sample ID."""
+    try:
+        # Use regex to find all occurrences of deg followed by numbers
+        deg_matches = re.findall(r'deg(\d+)', sample_id)
+        
+        if len(deg_matches) >= 2:
+            return int(deg_matches[0]), int(deg_matches[1])
+        elif len(deg_matches) == 1:
+            return int(deg_matches[0]), 0
+        else:
+            # If no deg pattern is found, try to extract numbers directly
+            num_matches = re.findall(r'(\d+)(?:hz|_)', sample_id.lower())
+            filtered_matches = [int(m) for m in num_matches if int(m) in [0, 36, 72, 108, 144, 180]]
+            
+            if len(filtered_matches) >= 2:
+                return filtered_matches[0], filtered_matches[1]
+            elif len(filtered_matches) == 1:
+                return filtered_matches[0], 0
+            else:
+                print(f"Warning: Could not extract degrees from {sample_id}")
+                return 0, 0
+    except Exception as e:
+        print(f"Error extracting degrees from {sample_id}: {e}")
+        return 0, 0
+
+def extract_checkpoint_number(checkpoint_key):
+    """Extract checkpoint number from the key."""
+    # Match model_epoch_X.pt pattern
+    match = re.search(r'model_epoch_(\d+)\.pt', checkpoint_key)
+    if match:
+        return int(match.group(1))
+    
+    # Fallback to cp pattern
+    match = re.search(r'_cp(\d+)$', checkpoint_key)
+    if match:
+        return int(match.group(1))
+    
+    return 0
+
+def load_checkpoint_data(material='plastic', frequency='500hz'):
+    """Load per-checkpoint influence data from metadata file."""
+    metadata_path = f'/Users/sbplab/Hank/sinetone_sliced/step_018_sliced/metadata/{material}_{frequency}_per_checkpoint_influence_metadata.json'
+    
+    try:
+        with open(metadata_path, 'r') as f:
+            data = json.load(f)
+        print(f"Successfully loaded per-checkpoint influence data from {metadata_path}")
+        return data
+    except FileNotFoundError:
+        print(f"File not found: {metadata_path}")
+        print("Please run compute_tracin_influence.py with --save-per-checkpoint-influence flag to generate per-checkpoint influence data")
+        return None
+    except json.JSONDecodeError:
+        print(f"Error decoding JSON from {metadata_path}")
+        return None
+
+def identify_test_pairs(data):
+    """Identify all test pairs for which we have per-checkpoint influence scores."""
+    test_pairs = set()
+    
+    # Pattern to match model_epoch format
+    pattern = re.compile(r'tracin_influence_(.+?)_model_epoch')
+    
+    for train_pair_data in data.values():
+        for key in train_pair_data.keys():
+            if 'tracin_influence_' in key and 'model_epoch' in key:
+                match = pattern.search(key)
+                if match:
+                    test_pairs.add(match.group(1))
+    
+    return sorted(list(test_pairs))
+
+def plot_influence_progression(data, test_pair, output_dir='tracin_visualizations/checkpoints'):
+    """
+    Plot the progression of influence scores across checkpoints for a test pair.
+    
+    Args:
+        data: The per-checkpoint influence data dictionary
+        test_pair: The test pair ID to plot for
+        output_dir: Directory to save the plots
+    """
+    # Extract test degrees
+    test_first_deg, test_second_deg = extract_degrees(test_pair)
+    
+    # Create a dictionary to track influence for each training pair across checkpoints
+    progression_data = defaultdict(dict)
+    
+    # Identify all checkpoints
+    all_checkpoints = set()
+    
+    # Collect progression data
+    for train_pair, train_data in data.items():
+        for key, score in train_data.items():
+            if f'tracin_influence_{test_pair}_model_epoch' in key:
+                checkpoint = extract_checkpoint_number(key)
+                progression_data[train_pair][checkpoint] = score
+                all_checkpoints.add(checkpoint)
+    
+    if not progression_data:
+        print(f"No per-checkpoint influence data found for test pair {test_pair}")
+        return
+    
+    # Sort checkpoints
+    all_checkpoints = sorted(list(all_checkpoints))
+    
+    # Plot 1: Overall influence progression across checkpoints (aggregated)
+    plt.figure(figsize=(14, 8))
+    
+    # Compute average/median influence across all training pairs per checkpoint
+    avg_influences = []
+    median_influences = []
+    checkpoint_labels = []
+    
+    for cp in all_checkpoints:
+        cp_scores = [progression_data[train_pair].get(cp, 0) for train_pair in progression_data if cp in progression_data[train_pair]]
+        if cp_scores:
+            avg_influences.append(np.mean(cp_scores))
+            median_influences.append(np.median(cp_scores))
+            checkpoint_labels.append(f"Epoch {cp}")
+    
+    # Plot averages
+    plt.plot(checkpoint_labels, avg_influences, marker='o', linestyle='-', linewidth=2, label='Mean Influence')
+    plt.plot(checkpoint_labels, median_influences, marker='s', linestyle='--', linewidth=2, label='Median Influence')
+    
+    # Add annotations for significant checkpoints (e.g., min/max)
+    min_idx = np.argmin(avg_influences)
+    max_idx = np.argmax(avg_influences)
+    
+    plt.annotate(f"Min: {avg_influences[min_idx]:.2f}", 
+                xy=(min_idx, avg_influences[min_idx]),
+                xytext=(min_idx, avg_influences[min_idx] - 0.5),
+                arrowprops=dict(facecolor='black', shrink=0.05),
+                fontsize=10)
+    
+    plt.annotate(f"Max: {avg_influences[max_idx]:.2f}", 
+                xy=(max_idx, avg_influences[max_idx]),
+                xytext=(max_idx, avg_influences[max_idx] + 0.5),
+                arrowprops=dict(facecolor='black', shrink=0.05),
+                fontsize=10)
+    
+    plt.title(f'Influence Progression Across Checkpoints for Test Pair {test_first_deg}°→{test_second_deg}°')
+    plt.xlabel('Checkpoint')
+    plt.ylabel('Average Influence Score')
+    plt.grid(True, linestyle='--', alpha=0.7)
+    plt.legend()
+    plt.tight_layout()
+    
+    plt.savefig(os.path.join(output_dir, f'influence_progression_{test_first_deg}_{test_second_deg}.png'))
+    print(f"Saved influence progression plot for test pair {test_first_deg}°→{test_second_deg}°")
+    
+    # Plot 2: Influence progression for top 5 most influential training pairs
+    plt.figure(figsize=(14, 8))
+    
+    # Find the top 5 most influential training pairs based on final checkpoint
+    final_checkpoint = max(all_checkpoints)
+    final_influences = {}
+    for train_pair in progression_data:
+        if final_checkpoint in progression_data[train_pair]:
+            final_influences[train_pair] = progression_data[train_pair][final_checkpoint]
+    
+    # Sort and get top 5
+    top_train_pairs = sorted(final_influences.items(), key=lambda x: abs(x[1]), reverse=True)[:5]
+    
+    # Plot each top pair's progression
+    for train_pair, _ in top_train_pairs:
+        train_first_deg, train_second_deg = extract_degrees(train_pair)
+        label = f"{train_first_deg}°→{train_second_deg}°"
+        
+        checkpoints = sorted(progression_data[train_pair].keys())
+        influences = [progression_data[train_pair][cp] for cp in checkpoints]
+        
+        plt.plot([f"Epoch {cp}" for cp in checkpoints], influences, marker='o', linestyle='-', label=label)
+    
+    plt.title(f'Influence Progression for Top 5 Most Influential Training Pairs on Test Pair {test_first_deg}°→{test_second_deg}°')
+    plt.xlabel('Checkpoint')
+    plt.ylabel('Influence Score')
+    plt.grid(True, linestyle='--', alpha=0.7)
+    plt.legend()
+    plt.tight_layout()
+    
+    plt.savefig(os.path.join(output_dir, f'top5_progression_{test_first_deg}_{test_second_deg}.png'))
+    print(f"Saved top 5 influence progression plot for test pair {test_first_deg}°→{test_second_deg}°")
+    
+    # Plot 3: Heatmap comparison of first vs last checkpoint
+    if len(all_checkpoints) >= 2:
+        first_cp = min(all_checkpoints)
+        last_cp = max(all_checkpoints)
+        
+        # Collect data for each train degree pair
+        first_cp_data = defaultdict(float)
+        last_cp_data = defaultdict(float)
+        
+        for train_pair in progression_data:
+            if first_cp in progression_data[train_pair] and last_cp in progression_data[train_pair]:
+                train_first_deg, train_second_deg = extract_degrees(train_pair)
+                pair_key = (train_first_deg, train_second_deg)
+                
+                first_cp_data[pair_key] += progression_data[train_pair][first_cp]
+                last_cp_data[pair_key] += progression_data[train_pair][last_cp]
+        
+        # Get all unique degrees
+        all_degrees = sorted(set([deg for pair in list(first_cp_data.keys()) + list(last_cp_data.keys()) for deg in pair]))
+        
+        if all_degrees:
+            # Create matrices for the heatmaps
+            first_matrix = np.zeros((len(all_degrees), len(all_degrees)))
+            last_matrix = np.zeros((len(all_degrees), len(all_degrees)))
+            diff_matrix = np.zeros((len(all_degrees), len(all_degrees)))
+            
+            # Fill matrices
+            for (first_deg, second_deg), score in first_cp_data.items():
+                if first_deg in all_degrees and second_deg in all_degrees:
+                    i = all_degrees.index(first_deg)
+                    j = all_degrees.index(second_deg)
+                    first_matrix[i, j] = score
+            
+            for (first_deg, second_deg), score in last_cp_data.items():
+                if first_deg in all_degrees and second_deg in all_degrees:
+                    i = all_degrees.index(first_deg)
+                    j = all_degrees.index(second_deg)
+                    last_matrix[i, j] = score
+                    diff_matrix[i, j] = score - first_matrix[i, j]
+            
+            # Create a figure with 3 subplots
+            fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+            
+            # Create diverging colormap with white at zero
+            cmap = sns.diverging_palette(240, 10, as_cmap=True)
+            
+            # First checkpoint heatmap
+            im1 = sns.heatmap(
+                first_matrix,
+                annot=True,
+                fmt=".1f",
+                cmap=cmap,
+                center=0,
+                xticklabels=[f"{d}°" for d in all_degrees],
+                yticklabels=[f"{d}°" for d in all_degrees],
+                ax=axes[0]
+            )
+            axes[0].set_title(f'First Checkpoint (Epoch {first_cp})')
+            axes[0].set_xlabel('Training Second Degree')
+            axes[0].set_ylabel('Training First Degree')
+            
+            # Last checkpoint heatmap
+            im2 = sns.heatmap(
+                last_matrix,
+                annot=True,
+                fmt=".1f",
+                cmap=cmap,
+                center=0,
+                xticklabels=[f"{d}°" for d in all_degrees],
+                yticklabels=[f"{d}°" for d in all_degrees],
+                ax=axes[1]
+            )
+            axes[1].set_title(f'Last Checkpoint (Epoch {last_cp})')
+            axes[1].set_xlabel('Training Second Degree')
+            axes[1].set_ylabel('Training First Degree')
+            
+            # Difference heatmap
+            im3 = sns.heatmap(
+                diff_matrix,
+                annot=True,
+                fmt=".1f",
+                cmap=cmap,
+                center=0,
+                xticklabels=[f"{d}°" for d in all_degrees],
+                yticklabels=[f"{d}°" for d in all_degrees],
+                ax=axes[2]
+            )
+            axes[2].set_title('Difference (Last - First)')
+            axes[2].set_xlabel('Training Second Degree')
+            axes[2].set_ylabel('Training First Degree')
+            
+            plt.suptitle(f'Influence Change from First to Last Checkpoint for Test Pair {test_first_deg}°→{test_second_deg}°')
+            plt.tight_layout()
+            
+            plt.savefig(os.path.join(output_dir, f'checkpoint_comparison_{test_first_deg}_{test_second_deg}.png'))
+            print(f"Saved checkpoint comparison heatmaps for test pair {test_first_deg}°→{test_second_deg}°")
+
+def plot_convergence_analysis(data, test_pairs, output_dir='tracin_visualizations/checkpoints'):
+    """
+    Analyze how quickly influence scores converge across checkpoints.
+    
+    Args:
+        data: The per-checkpoint influence data dictionary
+        test_pairs: List of test pairs to analyze
+        output_dir: Directory to save the plots
+    """
+    # Extract all checkpoint numbers
+    all_checkpoints = set()
+    for train_pair_data in data.values():
+        for key in train_pair_data.keys():
+            if 'model_epoch' in key:
+                cp = extract_checkpoint_number(key)
+                all_checkpoints.add(cp)
+    
+    all_checkpoints = sorted(list(all_checkpoints))
+    
+    if len(all_checkpoints) < 3:
+        print("Not enough checkpoints for convergence analysis")
+        return
+    
+    # For each test pair, compute variance reduction across checkpoints
+    plt.figure(figsize=(14, 8))
+    
+    legend_entries = []
+    
+    for test_pair in test_pairs[:min(5, len(test_pairs))]:
+        test_first_deg, test_second_deg = extract_degrees(test_pair)
+        legend_entry = f"{test_first_deg}°→{test_second_deg}°"
+        legend_entries.append(legend_entry)
+        
+        # For each checkpoint, compute variance of influence scores
+        variances = []
+        
+        for cp in all_checkpoints:
+            cp_scores = []
+            for train_pair, train_data in data.items():
+                key_pattern = f'tracin_influence_{test_pair}_model_epoch_{cp}.pt'
+                for key in train_data.keys():
+                    if key_pattern in key:
+                        cp_scores.append(train_data[key])
+            
+            if cp_scores:
+                variances.append(np.var(cp_scores))
+            else:
+                variances.append(0)
+        
+        # Normalize variances
+        if max(variances) > 0:
+            variances = [v / max(variances) for v in variances]
+        
+        # Plot variance reduction
+        plt.plot(all_checkpoints, variances, marker='o', linestyle='-', label=legend_entry)
+    
+    plt.title('Convergence Analysis: Normalized Variance of Influence Scores Across Checkpoints')
+    plt.xlabel('Checkpoint Epoch')
+    plt.ylabel('Normalized Variance')
+    plt.grid(True, linestyle='--', alpha=0.7)
+    plt.legend()
+    plt.tight_layout()
+    
+    plt.savefig(os.path.join(output_dir, 'influence_convergence.png'))
+    print("Saved influence convergence analysis plot")
+
+def main():
+    # Load the per-checkpoint influence data
+    data = load_checkpoint_data(material='plastic', frequency='500hz')
+    
+    if not data:
+        print("No data available. Exiting.")
+        return
+    
+    # Identify test pairs with per-checkpoint influence data
+    test_pairs = identify_test_pairs(data)
+    
+    if not test_pairs:
+        print("No test pairs found with per-checkpoint influence data.")
+        return
+    
+    print(f"Found {len(test_pairs)} test pairs with per-checkpoint influence data")
+    
+    # For each test pair, plot influence progression
+    for i, test_pair in enumerate(test_pairs[:min(5, len(test_pairs))]):  # Limit to 5 pairs for brevity
+        print(f"Processing test pair {i+1}/{min(5, len(test_pairs))}: {test_pair}")
+        plot_influence_progression(data, test_pair)
+    
+    # Plot convergence analysis across test pairs
+    plot_convergence_analysis(data, test_pairs)
+    
+    print("Visualization of checkpoint influences completed")
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
## 功能摘要

本PR添加了兩個新的可視化工具，用於分析模型訓練過程中不同檢查點的TracIn影響力變化：

1. `visualize_checkpoint_influences.py`：英文版可視化工具，生成針對每個測試樣本的影響力進展圖、最具影響力的訓練樣本趨勢圖，以及首末檢查點對比熱圖。

2. `analyze_per_checkpoint_influences.py`：中文版分析工具，生成詳細的文本分析報告，包括每個檢查點最具影響力的訓練樣本和影響力變化最顯著的樣本。

這些工具可以幫助理解模型在訓練過程中的行為變化，並識別出對預測結果影響最大的訓練樣本。

## 使用方法

要使用這些工具，首先需要運行`compute_tracin_influence.py`並加上`--save-per-checkpoint-influence`參數以生成每個檢查點的影響力數據。然後可以運行以下命令：

```bash
# 英文版可視化
python visualize_checkpoint_influences.py

# 中文版詳細分析
python analyze_per_checkpoint_influences.py --save-plots
```

生成的可視化將保存在`tracin_visualizations/checkpoints/`和`tracin_plots/`目錄中。